### PR TITLE
user_text判定の優先順位変更

### DIFF
--- a/app/models/recommended_movie/inquiry/message.rb
+++ b/app/models/recommended_movie/inquiry/message.rb
@@ -11,7 +11,7 @@ class RecommendedMovie::Inquiry::Message
     "今の気分はどうだ？",
     "最近どうだ？",
     "俺に聞くのか？",
-    "恋でもしてるのか"
+    "恋でもしてるのか？"
   ]
 
   NAITO_WORDS = [
@@ -32,12 +32,12 @@ class RecommendedMovie::Inquiry::Message
   class << self
     def create(user_text)
       case
-      when recommendation_word?(user_text)
-        create_old_man_message
       when naito_word?(user_text)
         create_naito_message(user_text)
       when almin_word?(user_text)
         create_almin_message
+      when recommendation_word?(user_text)
+        create_old_man_message
       else
         create_movie_recommendation_message!
       end


### PR DESCRIPTION
- 修正前：
1. `おすすめ`系
1. `内藤`系
1. `アルミン`

- 修正後：
1. `内藤`系
1. `アルミン`
1. `おすすめ`系

=>「内藤のおすすめ教えて」等のコメントの場合に`内藤`に最優先で反応してURLを返却するよう対応。
=> `アルミン`の文言が入っている場合も`おすすめ`より優先して反応するよう修正。

ついでに、`恋でもしてるのか`が疑問形になっていなかったので`？`追加。
